### PR TITLE
feat: add toNumber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules
 # Lock files
 package-lock.json
 yarn.lock
+.coverage

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,22 +39,7 @@ export class LongBits {
    * should be preferred
    */
   toNumber (unsigned?: boolean): number {
-    if (unsigned === true) {
-      return (this.lo >>> 0) + (this.hi >>> 0) << 32
-    }
-
-    if ((this.hi >>> 31) !== 0) {
-      const lo = ~this.lo + 1 >>> 0
-      let hi = ~this.hi >>> 0
-
-      if (lo === 0) {
-        hi = hi + 1 >>> 0
-      }
-
-      return -(lo + (hi << 32))
-    }
-
-    return (this.lo >>> 0) + ((this.hi >>> 0) << 32)
+    return Number(this.toBigInt(unsigned))
   }
 
   zzDecode () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,9 @@ export class LongBits {
     return Number(this.toBigInt(unsigned))
   }
 
+  /**
+   * ZigZag decode a LongBits object
+   */
   zzDecode () {
     const mask = -(this.lo & 1)
     const lo = ((this.lo >>> 1 | this.hi << 31) ^ mask) >>> 0
@@ -50,6 +53,9 @@ export class LongBits {
     return new LongBits(hi, lo)
   }
 
+  /**
+   * ZigZag encode a LongBits object
+   */
   zzEncode () {
     const mask = this.hi >> 31
     const hi = ((this.hi << 1 | this.lo >>> 31) ^ mask) >>> 0
@@ -58,6 +64,9 @@ export class LongBits {
     return new LongBits(hi, lo)
   }
 
+  /**
+   * Encode a LongBits object as a varint byte array
+   */
   toBytes (buf: Uint8ArrayList | Uint8Array, offset = 0) {
     const access = accessor(buf)
 
@@ -75,6 +84,9 @@ export class LongBits {
     access.set(offset++, this.lo)
   }
 
+  /**
+   * Parse a LongBits object from a BigInt
+   */
   static fromBigInt (value: bigint) {
     if (value === 0n) {
       return new LongBits()
@@ -105,6 +117,9 @@ export class LongBits {
     return new LongBits(hi, lo)
   }
 
+  /**
+   * Parse a LongBits object from a Number
+   */
   static fromNumber (value: number) {
     if (value === 0) {
       return new LongBits()
@@ -135,8 +150,16 @@ export class LongBits {
     return new LongBits(hi, lo)
   }
 
+  /**
+   * Parse a LongBits object from a varint byte array
+   */
   static fromBytes (buf: Uint8ArrayList | Uint8Array, offset: number = 0) {
     const access = accessor(buf)
+
+    // if the MSB of the final byte is not 0 we don't have all the bytes
+    if (access.get(buf.byteLength - 1) >> 7 === 1) {
+      throw RangeError('incomplete varint')
+    }
 
     // tends to deopt with local vars for octet etc.
     const bits = new LongBits()

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,9 @@ export class LongBits {
     this.lo = lo
   }
 
+  /**
+   * Returns these hi/lo bits as a BigInt
+   */
   toBigInt (unsigned?: boolean): bigint {
     if (unsigned === true) {
       return BigInt(this.lo >>> 0) + (BigInt(this.hi >>> 0) << 32n)
@@ -29,6 +32,29 @@ export class LongBits {
     }
 
     return BigInt(this.lo >>> 0) + (BigInt(this.hi >>> 0) << 32n)
+  }
+
+  /**
+   * Returns these hi/lo bits as a Number - this may overflow, toBigInt
+   * should be preferred
+   */
+  toNumber (unsigned?: boolean): number {
+    if (unsigned === true) {
+      return (this.lo >>> 0) + (this.hi >>> 0) << 32
+    }
+
+    if ((this.hi >>> 31) !== 0) {
+      const lo = ~this.lo + 1 >>> 0
+      let hi = ~this.hi >>> 0
+
+      if (lo === 0) {
+        hi = hi + 1 >>> 0
+      }
+
+      return -(lo + (hi << 32))
+    }
+
+    return (this.lo >>> 0) + ((this.hi >>> 0) << 32)
   }
 
   zzDecode () {
@@ -179,6 +205,6 @@ export class LongBits {
     }
 
     /* istanbul ignore next */
-    throw Error('invalid varint encoding')
+    throw RangeError('invalid varint encoding')
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -64,4 +64,14 @@ describe('longbits', () => {
 
     expect(bits.toNumber()).to.equal(val)
   })
+
+  it('should throw on incomplete byte array', () => {
+    const val = 6547656755453442n
+    const bits = LongBits.fromBigInt(val)
+    const bytes = new Uint8Array(8)
+    bits.toBytes(bytes)
+
+    expect(() => LongBits.fromBytes(bytes.slice(0, 2)))
+      .to.throw(RangeError)
+  })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -19,6 +19,26 @@ describe('longbits', () => {
     expect(bits.toBigInt()).to.equal(val)
   })
 
+  it('should round trip negative bigint as bytes', () => {
+    const val = -6547656755453442n
+    const bits = LongBits.fromBigInt(val)
+    const bytes = new Uint8Array(10)
+    bits.toBytes(bytes)
+
+    expect(LongBits.fromBytes(bytes).toBigInt()).to.equal(val)
+  })
+
+  it('should round trip small negative bigint as bytes with extra bytes', () => {
+    const val = -12345n
+    const bits = LongBits.fromBigInt(val)
+    const bytes = new Uint8Array(12)
+    bits.toBytes(bytes)
+    bytes[10] = 5
+    bytes[11] = 5
+
+    expect(LongBits.fromBytes(bytes).toBigInt()).to.equal(val)
+  })
+
   it('should interpret unsigned bigint', () => {
     const val = -6547656755453442n
     const bits = LongBits.fromBigInt(val)
@@ -73,5 +93,42 @@ describe('longbits', () => {
 
     expect(() => LongBits.fromBytes(bytes.slice(0, 2)))
       .to.throw(RangeError)
+  })
+
+  function randint (range: number) {
+    return Math.floor(Math.random() * range)
+  }
+
+  it('fuzz test', () => {
+    for (let i = 0, len = 100; i < len; ++i) {
+      const expected = randint(0x7FFFFFFF)
+      const buf = new Uint8Array(12)
+      LongBits.fromNumber(expected).toBytes(buf)
+
+      const data = LongBits.fromBytes(buf).toNumber(true)
+      expect(expected).to.equal(data, 'fuzz test: ' + expected.toString())
+    }
+  })
+
+  it('four-byte numbers', () => {
+    const buf = new Uint8Array(4)
+    LongBits.fromNumber(183950794).toBytes(buf)
+
+    expect(buf).to.equalBytes(Uint8Array.from([ 202, 187, 219, 87 ]))
+
+    expect(LongBits.fromBytes(buf).toNumber(true)).to.equal(183950794)
+  })
+
+  it('buffer too short', () => {
+    const buffer = new Uint8Array(6)
+    LongBits.fromNumber(9812938912312).toBytes(buffer)
+
+    let l = buffer.length
+    while (l-- > 0) {
+      const index = l
+      expect(() => {
+        LongBits.fromBytes(buffer.slice(0, index))
+      }).to.throw(RangeError)
+    }
   })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -114,7 +114,7 @@ describe('longbits', () => {
     const buf = new Uint8Array(4)
     LongBits.fromNumber(183950794).toBytes(buf)
 
-    expect(buf).to.equalBytes(Uint8Array.from([ 202, 187, 219, 87 ]))
+    expect(buf).to.equalBytes(Uint8Array.from([202, 187, 219, 87]))
 
     expect(LongBits.fromBytes(buf).toNumber(true)).to.equal(183950794)
   })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -51,10 +51,17 @@ describe('longbits', () => {
     expect(bits.zzDecode().toBigInt()).to.equal(val)
   })
 
-  it('should round trip numbee', () => {
+  it('should round trip number', () => {
     const val = 65476
     const bits = LongBits.fromNumber(val)
 
     expect(bits.toBigInt()).to.equal(BigInt(val))
+  })
+
+  it('should round trip number as number', () => {
+    const val = 65476
+    const bits = LongBits.fromNumber(val)
+
+    expect(bits.toNumber()).to.equal(val)
   })
 })


### PR DESCRIPTION
Adds a `.toNumber` method for when you want to interpret the hi/lo bytes as a number and not a BigInt.

This will obviously not work for large values.